### PR TITLE
docs: generalize ci template artifact guidance

### DIFF
--- a/admin-app/components/settings/SettingsForm.module.css
+++ b/admin-app/components/settings/SettingsForm.module.css
@@ -4,14 +4,17 @@
   max-width: 520px;
 }
 
-.form label span {
-  display: block;
-  font-size: 0.8rem;
-  color: var(--text-secondary);
-  margin-bottom: 6px;
+.field {
+  display: grid;
+  gap: 6px;
 }
 
-.form input {
+.fieldLabel {
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+}
+
+.fieldInput {
   width: 100%;
   padding: 8px 10px;
   border-radius: 8px;

--- a/admin-app/components/settings/SettingsForm.tsx
+++ b/admin-app/components/settings/SettingsForm.tsx
@@ -102,18 +102,20 @@ export function SettingsForm() {
 
   return (
     <form className={styles.form} onSubmit={handleSave}>
-      <label>
-        <span>Quiet hours (start – end)</span>
+      <label className={styles.field}>
+        <span className={styles.fieldLabel}>Quiet hours (start – end)</span>
         <input
+          className={styles.fieldInput}
           value={form.quietHours}
           onChange={(event) =>
             setForm((prev) => ({ ...prev, quietHours: event.target.value }))}
           placeholder="22:00 – 06:00"
         />
       </label>
-      <label>
-        <span>WhatsApp throttle per minute</span>
+      <label className={styles.field}>
+        <span className={styles.fieldLabel}>WhatsApp throttle per minute</span>
         <input
+          className={styles.fieldInput}
           type="number"
           min={0}
           value={form.throttlePerMinute}
@@ -124,9 +126,10 @@ export function SettingsForm() {
             }))}
         />
       </label>
-      <label>
-        <span>Opt-out list (comma separated)</span>
+      <label className={styles.field}>
+        <span className={styles.fieldLabel}>Opt-out list (comma separated)</span>
         <input
+          className={styles.fieldInput}
           value={form.optOutList.join(", ")}
           onChange={(event) =>
             setForm((prev) => ({

--- a/docs/PHASE0_CREDENTIAL_CHECKLIST.md
+++ b/docs/PHASE0_CREDENTIAL_CHECKLIST.md
@@ -98,6 +98,7 @@ Supabase storage buckets (create via Supabase dashboard or migrations):
 - `TEST_VENDOR_WA_ID` – WhatsApp ID for a staging vendor user.
 
 > ✅ **Gate**: Do not proceed to Phase 1 until every required secret above is
-> collected and securely stored in your deployment environment (Vercel/Supabase
-> Edge/Secrets Manager). Update `.env.sample` values locally only with
-> non-secret placeholders.
+> collected and securely stored in your deployment environment (for example,
+> Supabase Edge secrets, a managed secrets manager, or your hosting provider’s
+> vault). Update `.env.sample` values locally only with non-secret
+> placeholders.

--- a/docs/easymo-admin/README.md
+++ b/docs/easymo-admin/README.md
@@ -1,25 +1,26 @@
 # easymo-admin Templates
 
-This directory collects starter configuration files that can be copied into a new `easymo-admin` repository. The templates assume a Next.js application deployed on Vercel with Supabase as the primary backend. Each file is heavily commented so you can tailor it to your own needs before committing to the new project.
+This directory collects starter configuration files that can be copied into a new `easymo-admin` repository. The templates assume a Next.js application deployed with Supabase as the primary backend and GitHub Actions as the pipeline orchestrator. Each file is heavily commented so you can tailor it to your own needs before committing to the new project.
 
 ## Files included
 
-- [`github-actions-nextjs.yml`](./github-actions-nextjs.yml) – CI pipeline template that lints, tests, builds, and validates Supabase migrations with PNPM on Node 18.
-- [`vercel.json`](./vercel.json) – Vercel project configuration aligned with the desired deployment strategy (preview deployments for PRs, production on `main`).
+- [`github-actions-nextjs.yml`](./github-actions-nextjs.yml) – CI pipeline template that lints, tests, builds, and validates Supabase migrations using the detected JavaScript package manager.
+- [`deployment-playbook.md`](./deployment-playbook.md) – Opinionated rollout guide describing how to promote builds using the CI workflow artifacts.
 - [`supabase/migrations/0001_create_core_tables.sql`](./supabase/migrations/0001_create_core_tables.sql) – Example additive SQL migration that creates common auth, profile, and auditing tables with row level security.
 
 ## How to use the templates
 
 1. **Copy the files** into the matching locations of the new repository (for example, place the GitHub Action under `.github/workflows/`).
 2. **Update placeholders** such as email domains, organization names, and URL allowlists before committing.
-3. **Wire the required secrets and environment variables** in GitHub, Supabase, and Vercel. The tables below provide a checklist for each platform.
+3. **Wire the required secrets and environment variables** in GitHub, Supabase, and your hosting provider. The tables below provide a checklist for each platform.
 
 ### GitHub repository checklist
 
 | Task | Notes |
 | --- | --- |
 | Create private repo `easymo-admin` | MIT license, Node `.gitignore`.
-| Add branch protection on `main` | Require ≥1 review, passing Vercel check, block force-pushes/deletions.
+| Add branch protection on `main` | Require ≥1 review, block force-pushes/deletions.
+| Require status checks | Enforce the `CI / install-and-test` and `CI / verify-migrations` contexts created by the GitHub Actions workflow.
 | Configure Dependabot & CodeQL | Enable security alerts and the default code scanning workflow.
 | Store secrets | `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`, `SUPABASE_PROJECT_REF`, `SUPABASE_EDGE_FUNCTIONS_REGION`, plus `SUPABASE_ACCESS_TOKEN` if you use the migration job.
 
@@ -30,18 +31,20 @@ This directory collects starter configuration files that can be copied into a ne
 | Create project `easymo-admin` in `eu-west-1` | Start with a blank database.
 | Link Supabase CLI | `supabase link --project-ref <PROJECT_REF>` (store the access token securely).
 | Apply initial migration | `supabase db push` after reviewing `0001_create_core_tables.sql`.
-| Configure JWT & anon keys | Copy `anon`, `service_role`, and `jwt_secret` into GitHub/Vercel secrets.
+| Configure JWT & anon keys | Copy `anon`, `service_role`, and `jwt_secret` into GitHub/hosting provider secrets.
 | Set edge function region | Match `SUPABASE_EDGE_FUNCTIONS_REGION` to `eu-west-1` unless you deploy elsewhere.
 
-### Vercel project checklist
+### Hosting provider checklist
+
+Tailor these steps to match the platform you choose (for example, Supabase Hosting, Cloud Run, or another managed Node provider).
 
 | Task | Notes |
 | --- | --- |
-| Import repo to Vercel | Framework preset: Next.js, Node 18.
-| Configure build | Build command `pnpm run build`, output `.vercel/output` (matches `vercel.json`).
-| Map environment variables | Provide the Supabase values for production, preview, and build environments (see the secret names referenced in `vercel.json`).
-| Set preview & production rules | Preview on every PR; production on merges to `main`.
-| Enable image optimization | Default for Next.js – no extra config needed.
+| Provision the project | Create an environment that can run a Node 18 Next.js application. |
+| Configure build | Reuse the commands from the GitHub Actions workflow (`pnpm run build` by default) or adapt them for your package manager. |
+| Map environment variables | Provide the Supabase credentials and any integration secrets used by the application. |
+| Configure deployment rules | Align preview and production deployments with GitHub branches (PRs vs. `main`). |
+| Set up custom domains | Point staging/production domains to the hosting provider before launch. |
 
 ### Environment variable reference
 
@@ -54,8 +57,6 @@ Provide these values through secrets or dashboard configuration rather than comm
 - `SUPABASE_PROJECT_REF`
 - `SUPABASE_EDGE_FUNCTIONS_REGION`
 - `SUPABASE_ACCESS_TOKEN` (GitHub Actions only)
-- `VERCEL_ENV`
-- Vercel preview aliases such as `@next_public_supabase_url_preview` (configure via the Vercel dashboard)
 - `NEXTAUTH_URL` (optional, if you use NextAuth.js)
 - `NEXTAUTH_SECRET` (optional, if you use NextAuth.js)
 - Any application-specific keys such as messaging providers, analytics, or third-party API credentials.

--- a/docs/easymo-admin/deployment-playbook.md
+++ b/docs/easymo-admin/deployment-playbook.md
@@ -1,0 +1,59 @@
+# easymo-admin Deployment Playbook
+
+This playbook explains how to move changes from pull request to production
+using the provided GitHub Actions workflow. It complements the configuration
+templates in this directory and should live in the root of the new
+`easymo-admin` repository once copied.
+
+## 1. Required CI checks
+
+The workflow defined in `github-actions-nextjs.yml` produces two required
+contexts. Enable them as branch protection rules on `main` so that merges
+cannot proceed unless both succeed:
+
+| Context | What it runs |
+| --- | --- |
+| `CI / install-and-test` | Installs dependencies with the detected package manager, runs lint, unit tests, and builds the Next.js app. |
+| `CI / verify-migrations` | Re-installs tooling and executes `supabase db lint` (or your alias) to ensure migrations are safe to apply. |
+
+> Tip: if you rename the workflow or jobs, update branch protection rules to
+> use the new context names before merging.
+
+## 2. Promotion flow
+
+1. Open a pull request. The workflow runs on every push and on the PR. Wait for
+   both required contexts to pass.
+2. Once reviewed, merge into `main`. This triggers the workflow again on the
+   default branch, producing the same artifacts.
+3. Download the build artifact from the latest `CI / install-and-test` run.
+   - Static export platforms can deploy the artifact directly.
+   - For serverful hosts, promote the commit SHA associated with the workflow
+     run through your hosting provider.
+4. Deploy updated Supabase migrations using `supabase db push` or your release
+   automation once `CI / verify-migrations` passes.
+
+Document the exact hosting platform promotion steps (CLI commands or dashboard
+links) in your repository’s `RUNBOOK.md` so on-call engineers can execute them.
+
+## 3. Secrets matrix
+
+Maintain a secrets inventory alongside this playbook to avoid merge blockers
+when onboarding new environments. At minimum ensure:
+
+- GitHub repository secrets contain the Supabase keys referenced by the
+  workflow.
+- The hosting platform mirrors the same keys for runtime usage.
+- Supabase CLI access tokens are scoped to a service account, not a personal
+  user.
+
+## 4. Rollback plan
+
+1. Revert the offending commit on `main` (via GitHub UI or locally) and wait
+   for CI to complete.
+2. Redeploy the previous artifact from the workflow associated with the revert.
+3. If migrations were applied, run the appropriate rollback script or deploy a
+   compensating migration.
+4. Announce the rollback in the support channel and update the incident log.
+
+Record runbook links for migrations and hosting rollback commands next to this
+file to keep the procedure actionable.

--- a/docs/easymo-admin/github-actions-nextjs.yml
+++ b/docs/easymo-admin/github-actions-nextjs.yml
@@ -1,5 +1,5 @@
 # Copy this file to `.github/workflows/ci.yml` in the new repository.
-# It runs linting, tests, a production build, and Supabase migration checks using PNPM on Node 18.
+# It runs linting, tests, a production build, and Supabase migration checks using the detected package manager on Node 18.
 # Adjust the individual commands to match the scripts that exist in your package.json.
 
 name: CI
@@ -29,41 +29,79 @@ jobs:
       SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
       SUPABASE_PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}
       SUPABASE_EDGE_FUNCTIONS_REGION: ${{ secrets.SUPABASE_EDGE_FUNCTIONS_REGION }}
-      VERCEL_ENV: ${{ github.ref == 'refs/heads/main' && 'production' || 'preview' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Detect package manager
+        id: pkg
+        run: |
+          if [ -f pnpm-lock.yaml ]; then
+            echo "manager=pnpm" >>"$GITHUB_OUTPUT"
+            echo "install=pnpm install --frozen-lockfile" >>"$GITHUB_OUTPUT"
+            echo "run=pnpm run" >>"$GITHUB_OUTPUT"
+            echo "exec=pnpm exec" >>"$GITHUB_OUTPUT"
+            echo "cache=pnpm" >>"$GITHUB_OUTPUT"
+          elif [ -f yarn.lock ]; then
+            echo "manager=yarn" >>"$GITHUB_OUTPUT"
+            echo "install=yarn install --frozen-lockfile" >>"$GITHUB_OUTPUT"
+            echo "run=yarn" >>"$GITHUB_OUTPUT"
+            echo "exec=yarn" >>"$GITHUB_OUTPUT"
+            echo "cache=yarn" >>"$GITHUB_OUTPUT"
+          else
+            echo "manager=npm" >>"$GITHUB_OUTPUT"
+            echo "install=npm ci" >>"$GITHUB_OUTPUT"
+            echo "run=npm run" >>"$GITHUB_OUTPUT"
+            echo "exec=npx" >>"$GITHUB_OUTPUT"
+            echo "cache=npm" >>"$GITHUB_OUTPUT"
+          fi
+
       - name: Set up PNPM
+        if: steps.pkg.outputs.manager == 'pnpm'
         uses: pnpm/action-setup@v4
         with:
           version: 8
           run_install: false
 
+      - name: Enable Corepack
+        if: steps.pkg.outputs.manager != 'pnpm'
+        run: corepack enable
+
       - name: Set up Node.js 18
         uses: actions/setup-node@v4
         with:
           node-version: 18
-          cache: 'pnpm'
+          cache: ${{ steps.pkg.outputs.cache }}
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: ${{ steps.pkg.outputs.install }}
 
       - name: Lint
-        run: pnpm run lint --if-present
+        run: |
+          if node -e "const pkg=require('./package.json'); process.exit(pkg.scripts?.lint ? 0 : 1)"; then
+            ${{ steps.pkg.outputs.run }} lint
+          else
+            echo "No lint script defined; skipping."
+          fi
 
       - name: Run unit tests
-        run: pnpm run test -- --passWithNoTests
+        run: |
+          if node -e "const pkg=require('./package.json'); process.exit(pkg.scripts?.test ? 0 : 1)"; then
+            ${{ steps.pkg.outputs.run }} test -- --passWithNoTests
+          else
+            echo "No test script defined; skipping."
+          fi
 
       - name: Build Next.js application
-        run: pnpm run build
+        run: ${{ steps.pkg.outputs.run }} build
 
-      - name: Upload .vercel/output artifact (optional)
+      - name: Upload build artifact (optional)
         if: success()
         uses: actions/upload-artifact@v4
         with:
-          name: vercel-output
-          path: .vercel/output
+          name: next-build
+          path: |
+            .next
           if-no-files-found: ignore
 
   verify-migrations:
@@ -75,25 +113,50 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Detect package manager
+        id: pkg
+        run: |
+          if [ -f pnpm-lock.yaml ]; then
+            echo "manager=pnpm" >>"$GITHUB_OUTPUT"
+            echo "install=pnpm install --frozen-lockfile" >>"$GITHUB_OUTPUT"
+            echo "exec=pnpm exec" >>"$GITHUB_OUTPUT"
+            echo "cache=pnpm" >>"$GITHUB_OUTPUT"
+          elif [ -f yarn.lock ]; then
+            echo "manager=yarn" >>"$GITHUB_OUTPUT"
+            echo "install=yarn install --frozen-lockfile" >>"$GITHUB_OUTPUT"
+            echo "exec=yarn" >>"$GITHUB_OUTPUT"
+            echo "cache=yarn" >>"$GITHUB_OUTPUT"
+          else
+            echo "manager=npm" >>"$GITHUB_OUTPUT"
+            echo "install=npm ci" >>"$GITHUB_OUTPUT"
+            echo "exec=npx" >>"$GITHUB_OUTPUT"
+            echo "cache=npm" >>"$GITHUB_OUTPUT"
+          fi
+
       - name: Set up PNPM (required for Supabase CLI via devDependencies)
+        if: steps.pkg.outputs.manager == 'pnpm'
         uses: pnpm/action-setup@v4
         with:
           version: 8
           run_install: false
 
+      - name: Enable Corepack
+        if: steps.pkg.outputs.manager != 'pnpm'
+        run: corepack enable
+
       - name: Set up Node.js 18
         uses: actions/setup-node@v4
         with:
           node-version: 18
-          cache: 'pnpm'
+          cache: ${{ steps.pkg.outputs.cache }}
 
       - name: Install Supabase CLI dependencies
-        run: pnpm install --frozen-lockfile
+        run: ${{ steps.pkg.outputs.install }}
 
       - name: Validate Supabase migrations
         # Swap this command for `pnpm supabase db push --dry-run` if you
         # maintain a script alias in package.json.
-        run: pnpm exec supabase db lint
+        run: ${{ steps.pkg.outputs.exec }} supabase db lint
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
           SUPABASE_PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}

--- a/docs/env/env.sample
+++ b/docs/env/env.sample
@@ -14,7 +14,8 @@ SUPABASE_JWT_SECRET=
 NEXT_PUBLIC_ENVIRONMENT_LABEL=Staging
 NEXT_PUBLIC_USE_MOCKS=false
 
-# Optional UI integrations (degrade gracefully when unset)
+# --- Optional UI Integrations ---
+# Degrade gracefully when left blank.
 NEXT_PUBLIC_VOUCHER_PREVIEW_ENDPOINT=
 NEXT_PUBLIC_WHATSAPP_SEND_ENDPOINT=
 NEXT_PUBLIC_CAMPAIGN_DISPATCHER_ENDPOINT=


### PR DESCRIPTION
## Summary
- clarify that the CI template auto-detects the package manager instead of assuming pnpm
- remove the Vercel-specific artifact path so hosts can rely on the Next.js build output alone

## Testing
- npm test -- --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_68e584e0a0888325be78d0b16fda75aa